### PR TITLE
Update torch.cuda.memory API calls for memory profiling

### DIFF
--- a/transformer_nuggets/utils/benchmark.py
+++ b/transformer_nuggets/utils/benchmark.py
@@ -105,6 +105,4 @@ def save_memory_snapshot(file_path: Path):
         with open(f"{file_path}/snapshot.pickle", "wb") as f:
             dump(s, f)
         with open(f"{file_path}/trace_plot.html", "w") as f:
-            f.write(torch.cuda.memory.trace_plot(s))
-        with open(f"{file_path}/segment_plot.html", "w") as f:
-            f.write(torch.cuda.memory.segment_plot(s))
+            f.write(torch.cuda._memory_viz.trace_plot(s))


### PR DESCRIPTION
trace_plot() and segment_plot() now live in _memory_viz and not memory. Also, since the snapshot.pickle and the plots are each sufficient in bringing up the same stuff (cache history, segment plot, trace plot), save only the snapshot.pickle and trace_plot.html.

The snapshot.pickle is good for those who are used to dragging the pickle file to https://zdevito.github.io/assets/viz/ and the trace_plot.html is good for those who just want the html to show up.