### PR TITLE
Add benchmark fp8 script

### DIFF
--- a/benchmarks/fp8_sat_cast.py
+++ b/benchmarks/fp8_sat_cast.py
@@ -1,0 +1,123 @@
+import itertools
+from dataclasses import dataclass
+
+from typing import List
+
+import torch
+
+from tabulate import tabulate
+from tqdm import tqdm
+
+from transformer_nuggets.fp8.scaled_quant import eager_scaled_quant, scaled_quant
+from transformer_nuggets.utils import benchmark_torch_function_in_microseconds
+
+device = torch.device("cuda")
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    numel: int
+    high_precision_dtype: torch.dtype
+    low_precision_dtype: torch.dtype
+    saturated: bool = False
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    triton_time: float
+    pytorch_time: float
+
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    result: ExperimentResult
+
+
+def get_configs() -> List[ExperimentConfig]:
+    sizes = [2**i for i in range(5, 20)]
+    high_precision_dtypes = [torch.bfloat16, torch.float16, torch.float32]
+    low_precision_dtypes = [torch.float8_e4m3fn, torch.float8_e5m2]
+    saturated = [True, False]
+    configs = []
+    for size, high_precision_dtype, low_precision_dtype, sat in itertools.product(
+        sizes, high_precision_dtypes, low_precision_dtypes, saturated
+    ):
+        configs.append(
+            ExperimentConfig(
+                numel=size,
+                high_precision_dtype=high_precision_dtype,
+                low_precision_dtype=low_precision_dtype,
+                saturated=sat,
+            )
+        )
+    return configs
+
+
+def run_experiment(config: ExperimentConfig) -> ExperimentResult:
+    high_precision_tensor = torch.randn(
+        config.numel, dtype=config.high_precision_dtype, device=device
+    )
+    triton_hp_tensor = high_precision_tensor.clone()
+
+    eager_abs_max = torch.empty(1, dtype=torch.float32, device=device)
+    triton_abs_max = torch.empty(1, dtype=torch.float32, device=device)
+
+    scale = torch.rand(1, dtype=torch.float32, device=device)
+
+    triton_time = benchmark_torch_function_in_microseconds(
+        scaled_quant,
+        triton_hp_tensor,
+        scale,
+        triton_abs_max,
+        config.low_precision_dtype,
+        config.saturated,
+    )
+    pytorch_time = benchmark_torch_function_in_microseconds(
+        eager_scaled_quant,
+        high_precision_tensor,
+        scale,
+        eager_abs_max,
+        config.low_precision_dtype,
+        config.saturated,
+    )
+    return ExperimentResult(triton_time=triton_time, pytorch_time=pytorch_time)
+
+
+def print_results(experiments: List[Experiment]):
+    headers = [
+        "numel",
+        "high_precision_dtype",
+        "low_precision_dtype",
+        "saturated",
+        "triton_time",
+        "pytorch_time",
+    ]
+    rows = []
+    for experiment in experiments:
+        rows.append(
+            [
+                experiment.config.numel,
+                experiment.config.high_precision_dtype,
+                experiment.config.low_precision_dtype,
+                experiment.config.saturated,
+                experiment.result.triton_time,
+                experiment.result.pytorch_time,
+            ]
+        )
+    print(tabulate(rows, headers=headers))
+
+
+def main():
+    configs = get_configs()
+    results = []
+    for config in tqdm(configs):
+        result = run_experiment(config)
+        results.append(Experiment(config=config, result=result))
+
+    # Use Tabulate to print results
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/fp8_sat_cast.py
+++ b/benchmarks/fp8_sat_cast.py
@@ -82,16 +82,18 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
         config.low_precision_dtype,
         config.saturated,
     )
-    compiled_pytorch_fn = torch.compile(eager_scaled_quant, fullgraph=True)
-    compiled_pytorch_time = benchmark_torch_function_in_microseconds(
-        compiled_pytorch_fn,
-        high_precision_tensor,
-        scale,
-        eager_abs_max,
-        config.low_precision_dtype,
-        config.saturated,
+    # compiled_pytorch_fn = torch.compile(eager_scaled_quant, fullgraph=True)
+    # compiled_pytorch_time = benchmark_torch_function_in_microseconds(
+    #     compiled_pytorch_fn,
+    #     high_precision_tensor,
+    #     scale,
+    #     eager_abs_max,
+    #     config.low_precision_dtype,
+    #     config.saturated,
+    # )
+    return ExperimentResult(
+        triton_time=triton_time, pytorch_time=pytorch_time, compiled_pytorch_time=0
     )
-    return ExperimentResult(triton_time=triton_time, pytorch_time=pytorch_time, compiled_pytorch_time=compiled_pytorch_time)
 
 
 def print_results(experiments: List[Experiment]):
@@ -102,7 +104,7 @@ def print_results(experiments: List[Experiment]):
         "saturated",
         "triton_time",
         "pytorch_time",
-        "compiled_pytorch_time"
+        "compiled_pytorch_time",
     ]
     rows = []
     for experiment in experiments:

--- a/transformer_nuggets/fp8/scaled_quant.py
+++ b/transformer_nuggets/fp8/scaled_quant.py
@@ -64,3 +64,30 @@ def scaled_quant(
         inpt_tensor, out_tensor, scale, abs_max, numel, 4096, tl_dtype, max_val, num_warps=8
     )
     return out_tensor
+
+
+def eager_scaled_quant(
+    a: torch.Tensor,
+    scale: torch.Tensor,
+    abs_max: torch.Tensor,
+    fp8_dtype: torch.dtype,
+    saturated: torch.dtype = False,
+):
+    """Quantize tensor to fp8 using a delayed scaled and calculate abs_max
+
+    Args:
+        a: Input tensor to quantize
+        scale: Scale to apply to input tensor, calculated from previous abs_max
+        abs_max: Absolute maximum value of input tensor, will be updated
+        fp8_dtype: FP8 datatype to quantize to
+        saturated: Whether to saturate the output tensor to the maximum value
+            of the fp8 datatype
+    """
+    out = a * scale
+    if saturated:
+        out = torch.where(out > torch.finfo(fp8_dtype).max, torch.finfo(fp8_dtype).max, out)
+        out = torch.where(
+            out < -1 * torch.finfo(fp8_dtype).max, -1 * torch.finfo(fp8_dtype).max, out
+        )
+    abs_max = torch.max(torch.abs(out))
+    return out.to(fp8_dtype)

--- a/transformer_nuggets/fp8/scaled_quant.py
+++ b/transformer_nuggets/fp8/scaled_quant.py
@@ -17,6 +17,7 @@ def scaled_cast(
     """Quantize tensor to fp8 using a delayed scaled and calculate abs_max"""
     offset = tl.program_id(0) * XBLOCK
     index = offset + tl.arange(0, XBLOCK)[:]
+    index = tl.max_contiguous(tl.multiple_of(index, XBLOCK), XBLOCK)
     mask = index < numel
     inpt = tl.load(inpt_ptr + (index), mask=mask)
     block_max = tl.max(tl.abs(inpt))


### PR DESCRIPTION
```Shell
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 32/32 [02:29<00:00,  4.67s/it]
   numel  high_precision_dtype    low_precision_dtype    saturated      triton_time    pytorch_time    compiled_pytorch_time
--------  ----------------------  ---------------------  -----------  -------------  --------------  -----------------------
 2097152  torch.bfloat16          torch.float8_e4m3fn    True               39.4022         59.9545                  75.0129
 2097152  torch.bfloat16          torch.float8_e4m3fn    False              39.193          27.1596                  29.506
 2097152  torch.bfloat16          torch.float8_e5m2      True               39.1569         60.187                   79.2593
 2097152  torch.bfloat16          torch.float8_e5m2      False              38.8475         27.2665                  29.2743
 2097152  torch.float32           torch.float8_e4m3fn    True               39.8845         59.7176                  69.8467
 2097152  torch.float32           torch.float8_e4m3fn    False              38.8206         25.6547                  30.5112
 2097152  torch.float32           torch.float8_e5m2      True               39.5862         60.5091                  69.3323
 2097152  torch.float32           torch.float8_e5m2      False              39.2996         25.6836                  30.4653
 4194304  torch.bfloat16          torch.float8_e4m3fn    True               39.5744         89.2462                  89.2371
 4194304  torch.bfloat16          torch.float8_e4m3fn    False              39.4241         44.5693                  44.5856
 4194304  torch.bfloat16          torch.float8_e5m2      True               39.5765         89.2892                  89.3438
 4194304  torch.bfloat16          torch.float8_e5m2      False              39.51           45.5271                  45.5449
 4194304  torch.float32           torch.float8_e4m3fn    True               39.0992         88.103                   88.1655
 4194304  torch.float32           torch.float8_e4m3fn    False              38.7692         43.3739                  43.3968
 4194304  torch.float32           torch.float8_e5m2      True               39.4078         88.1485                  88.1937
 4194304  torch.float32           torch.float8_e5m2      False              39.0674         44.4441                  44.4622
 8388608  torch.bfloat16          torch.float8_e4m3fn    True               38.9665        201.205                  201.236
 8388608  torch.bfloat16          torch.float8_e4m3fn    False              38.6342         98.2023                  98.2161
 8388608  torch.bfloat16          torch.float8_e5m2      True               39.0337        201.23                   201.231
 8388608  torch.bfloat16          torch.float8_e5m2      False              38.9622         99.2762                  99.3148
 8388608  torch.float32           torch.float8_e4m3fn    True               39.4607        206.298                  206.345
 8388608  torch.float32           torch.float8_e4m3fn    False              38.7217         98.8632                  98.9315
 8388608  torch.float32           torch.float8_e5m2      True               38.9956        206.25                   206.253
 8388608  torch.float32           torch.float8_e5m2      False              38.9852         99.7639                  99.8383
16777216  torch.bfloat16          torch.float8_e4m3fn    True               39.6764        456.835                  456.883
16777216  torch.bfloat16          torch.float8_e4m3fn    False              38.617         217.268                  217.277
16777216  torch.bfloat16          torch.float8_e5m2      True               39.1838        456.872                  456.897
16777216  torch.bfloat16          torch.float8_e5m2      False              38.7144        218.301                  218.347
16777216  torch.float32           torch.float8_e4m3fn    True               43.0035        457.834                  457.869
16777216  torch.float32           torch.float8_e4m3fn    False              42.993         214.077                  214.139
16777216  torch.float32           torch.float8_e5m2      True               42.9996        457.954                  458.012
16777216  torch.float32           torch.float8_e5m2      False              42.9937        215.222                  215.239
```