### PR TITLE
[WIP] full finetune / qlora + ac/offload/optm in bwd

### DIFF
--- a/transformer_nuggets/llama/finetune.py
+++ b/transformer_nuggets/llama/finetune.py
@@ -3,7 +3,7 @@
 python transformer_nuggets/llama/finetune.py --profile --model 7B --enable_ac --full_finetune --optim_in_bwd
 
 # qlora on 2 gpus with FSDP
-python transformer_nuggets/llama/finetune.py --profile --model 7B --fsdp_num_gpus 2 --use_fsdp2 --enable_ac --cpu_offload
+python transformer_nuggets/llama/finetune.py --profile --model 7B --fsdp_num_gpus 2 --use_fsdp2 --enable_ac --register_nf4_param --cpu_offload
 """
 import argparse
 import functools

--- a/transformer_nuggets/llama/model.py
+++ b/transformer_nuggets/llama/model.py
@@ -58,6 +58,7 @@ transformer_configs = {
     "CodeLlama-7b-Python-hf": dict(
         block_size=16384, vocab_size=32000, n_layer=32, dim=4096, rope_base=1000000
     ),
+    "mini": dict(n_layer=2, n_head=32, dim=4096),
     "7B": dict(n_layer=32, n_head=32, dim=4096),
     "13B": dict(n_layer=40, n_head=40, dim=5120),
     "30B": dict(n_layer=60, n_head=52, dim=6656),


### PR DESCRIPTION
## Why composing FSDP with NF4Tensor

**QLoRA** : number of trainable parameters are reduced from xxx to xxx. parameter size are reduced by xx
Full finetuning original Llama with 4bit quantized params:

7B + QLora on FFNs: summarizing memory usage below with bf16, adamW, AC, cpu offloading
* sharding NF4Tensor in FSDP: NF4Tensor are 4 bit quant weight from QLora
* cpu offloading NF4Tensor in FSDP: most profitabble
* gradient in the backward, 8bit optimizer: does not matter in QLora because of tiny gradable parameters. should priooritize in full training

<img width="625" alt="Screenshot 2024-02-26 at 12 50 45 PM" src="https://github.com/drisspg/transformer_nuggets/assets/134637289/6eedb2eb-524e-49c5-85d2-4e64ca7c896a">

<img width="249" alt="Screenshot 2024-02-27 at 12 39 54 PM" src="https://github.com/drisspg/transformer_nuggets/assets/134637289/7a546e28-5b01-4fbc-968d-3efabeaca7c0">

