### PR TITLE
Transpose throws an annoying wrench in the mix

### DIFF
--- a/test/test_qlora.py
+++ b/test/test_qlora.py
@@ -223,5 +223,4 @@ def test_linear_dispatch():
     x = torch.rand(32, 512, device=device, dtype=torch.bfloat16)
     out_dispatch = F.linear(x, weight)
     out_autograd_func = qlora.linear_nf4(x, weight)
-    # E       NotImplementedError: NF4Tensor dispatch: attempting to run aten.t.default, this is not supported
-    assert all(out_dispatch == out_autograd_func)
+    assert torch.sum(out_dispatch - out_autograd_func) == 0

--- a/transformer_nuggets/quant/nf4_tensor.py
+++ b/transformer_nuggets/quant/nf4_tensor.py
@@ -33,6 +33,22 @@ class SubclassTensorArgs:
     requires_grad: bool
 
 
+@implements([aten.mm.default])
+def nf4_mm(aten_op, args, kwargs=None):
+    """Matrix multiply for NF4 Tensors"""
+    input, weight = args
+    assert isinstance(weight, NF4Tensor), "Weight must be a NF4Tensor"
+    return torch.mm(input, weight.get_original_weight())
+
+
+@implements([aten.addmm.default])
+def nf4_addmm(aten_op, args, kwargs=None):
+    """Add matrix multiply for NF4 Tensors"""
+    input, weight, bias = args
+    assert isinstance(weight, NF4Tensor), "Weight must be a NF4Tensor"
+    return torch.addmm(bias, input, weight.get_original_weight())
+
+
 def get_block_absmax(inpt_tensor: torch.Tensor, block_size: int) -> torch.Tensor:
     """Iterate through a flattened tensor getting the absmax scalers for each block
 


### PR DESCRIPTION
# Summary

When you call torch.nn.F.linear() you will call transpose on the weight.

One solution for doing this is to lazily compute the transpose, which is mark that the matrix needs to be transposed when it encounters a realizing op. In this case that would be addmm and mm. Did not handle correctly double even transposes cause I think that's unlikely 