### PR TITLE
Add ShapeLog mode to utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "torch >= 2.1.1",
     "scipy >= 1.9.1",
     "tqdm >= 4.66",
-    "tabulate >= 0.8"
+    "tabulate >= 0.8",
+    "rich==13.7.1"
 ]
 
 [project.optional-dependencies]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,10 @@
+import tempfile
 import unittest.mock as mock
+from pathlib import Path
 
 import pytest
 import torch
+from transformer_nuggets.utils.shape_trace import open_logs, ShapeLog
 from transformer_nuggets.utils.tracing import NanInfDetect
 
 
@@ -37,6 +40,28 @@ def test_breakpoint():
     ) as mock_breakpoint, NanInfDetect(do_breakpoint=True):
         print(torch.div(a, a))
         mock_breakpoint.assert_called_once()
+
+
+def test_shape_log():
+    # Create an in-memory file-like object
+    temp_file = tempfile.NamedTemporaryFile(delete=False)
+    temp_path = Path(temp_file.name)
+
+    aten = torch.ops.aten
+    mode = ShapeLog(temp_path)
+
+    with mode:
+        torch.nn.functional.linear(torch.randn(3, 4), torch.randn(5, 4))
+    logs = open_logs(temp_path)
+    assert str(aten.mm.default) in logs.keys()
+    assert str(aten.randn.default) in logs.keys()
+
+    mm_ops = [aten.mm.default]
+    with ShapeLog(temp_path, specific_ops=mm_ops):
+        torch.nn.functional.linear(torch.randn(3, 4), torch.randn(5, 4))
+    logs = open_logs(temp_path)
+    assert str(aten.mm.default) in logs.keys()
+    assert str(aten.randn.default) not in logs.keys()
 
 
 if __name__ == "__main__":

--- a/transformer_nuggets/utils/shape_trace.py
+++ b/transformer_nuggets/utils/shape_trace.py
@@ -1,0 +1,150 @@
+""" Iterate through torchbench models and collect info on shapes of inputs and outputs """
+
+import ast
+
+import logging
+import pickle as pkl
+from collections import Counter, defaultdict
+
+from pathlib import Path
+
+from typing import Dict, Optional
+
+import torch
+import torch.overrides
+from rich import print as rprint
+from torch.fx.operator_schemas import normalize_function
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import tree_map
+
+from transformer_nuggets.utils.benchmark import bcolors
+
+from transformer_nuggets.utils.tracing import abbr_to_dtype, dtype_abbrs
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+class ShapeLog(TorchDispatchMode):
+    """Example usage:
+    with LoggingMode():
+        torch.nn.functional.linear(torch.randn(3, 4), torch.randn(5, 4))
+    """
+
+    def __init__(self, log_path, with_type: bool = True, specific_ops=None):
+        self.with_type = with_type
+        self.log_path = log_path
+        self.logs = defaultdict(Counter)
+        self.specific_ops = specific_ops
+
+    def _fmt(self, a: object) -> str:
+        if isinstance(a, torch.Tensor):
+            maybe_type = ""
+            shape_str = f"[{','.join(map(str, a.shape))}]"
+            if self.with_type:
+                maybe_type = dtype_abbrs[a.dtype]
+            return f"{maybe_type}{shape_str}"
+        else:
+            return a
+
+    def fmt_shape(self, kwargs: Dict, with_type: bool = False) -> str:
+        """This formats the tensor args and output into a string that is easy to parse
+        Specifically:
+         The input string will be broken up into two sections seperated by a ->
+            - The first section will contain the input shapes of the tensors in the format
+            <kwarg_name>=[shape1],<kwarg_name>=[shape2],...,[shapeN]
+            - The second section will contain the output shape of the tensor in the format
+            [shape]
+
+        if with_type is True, then the shapes will be formatted with their respective types
+            - Example: float32[1, 2, 3]
+        """
+        input_str = "|".join(f"{k}:{tree_map(self._fmt, v)}" for k, v in kwargs.items())
+        return input_str
+
+    def print_logs(self):
+        rprint(self.logs)
+
+    def save_to_disk(self, path: Path):
+        with open(path, "wb") as f:
+            pkl.dump(self.logs, f)
+        logger.info(f"💾 Trace file 📄 saved to: {bcolors.OKGREEN}{path}{bcolors.ENDC}")
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        # Only log the specific ops if they are provided
+        if self.specific_ops is not None and func not in self.specific_ops:
+            return func(*args, **kwargs)
+        if kwargs is None:
+            kwargs = {}
+        rs = func(*args, **kwargs)
+
+        # Convert all to kwargs
+        _, new_kwargs = normalize_function(
+            func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
+        )
+
+        fmt_args = self.fmt_shape(new_kwargs)
+        delimiter = "->"
+        fmt_rets = tree_map(self._fmt, rs)
+        log_msg = f"{fmt_args}{delimiter}{fmt_rets}"
+
+        self.logs[str(func)][log_msg] += 1
+        return rs
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.save_to_disk(self.log_path)
+        return super().__exit__(exc_type, exc_val, exc_tb)
+
+
+def open_logs(path: Path):
+    """Opens the logs file and returns the logs dict object"""
+    with open(path, "rb") as f:
+        return pkl.load(f)
+
+
+def construct_input(
+    log: dict,
+    op,
+    device: torch.device,
+    default_dtype: torch.dtype = torch.float32,
+    requires_grad: bool = False,
+    most_common: Optional[int] = None,
+):
+    """Parses the log string and returns the input and output shapes
+    Args:
+        log: The log dictionary
+        op: The name of the op
+        device: The device to put the tensors on
+        default_dtype: The default dtype of the tensors if not dype
+            was saved during logging. Defaults to torch.float32.
+        requires_grad: Whether the tensors require grad. Defaults to False.
+        most_common: The number of most common shapes to return. Defaults to None.
+
+    Returns:
+        A list of dictionaries containing the inputs that can be used with the specified op
+        Up to the N most common entries
+    """
+    input_to_self = lambda name: name if name != "input" else "self"
+    op_entries = log[str(op)].most_common(most_common)
+    op_inpts = []
+    for entry in op_entries:
+        input_str, output_str = entry[0].split("->")
+        input_str = input_str.split("|")
+        input_dict = {}
+        for pair in input_str:
+            k, v = pair.split(":")
+            # Check if dtype is present
+            assert (
+                "[" in v
+            ), f"Shape is not present in {v}, you are calling a function that accepts non tensor kwargs and I have yet to create string serialization for these"
+            maybe_dtype_tuple = v.split("[")
+            maybe_dtype = maybe_dtype_tuple[0]
+            shape = "[" + maybe_dtype_tuple[1]
+            shape = ast.literal_eval(shape)
+            dtype = abbr_to_dtype[maybe_dtype] if maybe_dtype else default_dtype
+            # Need to convert the input name to self if it is input
+            input_dict[input_to_self(k)] = torch.rand(
+                shape, dtype=dtype, device=device, requires_grad=requires_grad
+            )
+        op_inpts.append(input_dict)
+    return op_inpts

--- a/transformer_nuggets/utils/tracing.py
+++ b/transformer_nuggets/utils/tracing.py
@@ -26,6 +26,8 @@ dtype_abbrs = {
     torch.float8_e5m2: "f8e5m2",
 }
 
+abbr_to_dtype = {v: k for k, v in dtype_abbrs.items()}
+
 
 class Lit:
     def __init__(self, s):


### PR DESCRIPTION
# Summary

Can be used to get the shapes, and counts of inputs to aten ops

Sample usage:
``` Python
aten = torch.ops.aten
sdpa_ops = [aten._scaled_dot_product_flash_attention.default, aten._scaled_dot_product_efficient_attention.default]
mm_ops = [aten.mm.default, aten.bmm.default, aten.addmm.default]
conv_ops = [aten.conv1d.default, aten.conv2d.default, aten.conv3d.default]
with ShapeLog("torchbench_logs_mm_ops.pkl", specific_ops=mm_ops):
    main()

logs = open_logs(temp_path)

```