### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,13 @@
 
 - Use `agent_space/` (git-ignored, at repo root) for temporary scripts, scratch files, and throwaway experiments.
 - Do not commit files from this directory.
+
+## Cursor Cloud specific instructions
+
+This is a Python research library (`transformer_nuggets`, PyTorch + Triton). There is no long-running service/app — work is via the library, examples, tests, and CLI scripts.
+
+- Python deps live in a virtualenv at `.venv` (created by the update script). Run tools with `.venv/bin/python`, `.venv/bin/pytest`, `.venv/bin/ruff` (or activate it). Install command mirrors CI: `pip install -e ".[dev]"`.
+- The cloud VM is CPU-only (no GPU / no `nvidia-smi`). `torch.cuda.is_available()` is `False`. Many tests and most `examples/` (fp8, mx, cute DSL, memory_viz, etc.) require CUDA and will auto-skip or fail to run; this is expected, not an environment problem.
+- Lint: `.venv/bin/ruff check .` and `.venv/bin/ruff format --check .` (these mirror the `prek`/pre-commit + CI checks).
+- Tests: `.venv/bin/pytest`. Default config (`pyproject.toml`) deselects `slow` tests; run them with `pytest -m slow`. On CPU expect a large number of `skipped` (GPU) tests.
+- Known pre-existing breakage (not env-related): `test/test_perfetto.py` fails to collect because it imports `chrome_trace_to_track_event_trace` / `default_track_event_path`, which no longer exist in `transformer_nuggets/utils/perfetto.py`. Run the rest of the suite with `pytest --ignore=test/test_perfetto.py` until that test is fixed upstream.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `transformer_nuggets` (a Python PyTorch + Triton research library) for Cursor Cloud agents and documents durable, non-obvious caveats.

### What was done
- Installed deps into a `.venv` virtualenv via `pip install -e ".[dev]"` (mirrors CI). The cloud VM is CPU-only (no GPU), so `torch.cuda.is_available()` is `False` and GPU tests auto-skip.
- Configured the startup update script: `python3 -m venv .venv` + `.venv/bin/pip install -e ".[dev]"`.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering: venv usage, CPU-only caveat, lint/test commands, and a pre-existing `test/test_perfetto.py` collection failure.

### Verification (CPU)
| Step | Command | Result |
| --- | --- | --- |
| Lint | `ruff check .` / `ruff format --check .` | All checks passed / 85 files formatted |
| Tests | `pytest --ignore=test/test_perfetto.py` | 111 passed, 35 skipped (GPU), 6 deselected |
| Hello-world | perfetto `split_overlapping_slices` round-trip + torch softmax | OK |

### Note (pre-existing, not env-related)
`test/test_perfetto.py` fails to collect because it imports `chrome_trace_to_track_event_trace` / `default_track_event_path`, which no longer exist in `transformer_nuggets/utils/perfetto.py`. Left unmodified per setup scope.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c3f4fcd-2fbd-42f2-bc33-aded2130d2fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c3f4fcd-2fbd-42f2-bc33-aded2130d2fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

